### PR TITLE
Add Kafka Topic Writing Feature to KViewer

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+
+	"github.com/IBM/sarama"
 	"github.com/spf13/viper"
 )
 
@@ -10,4 +13,23 @@ func setupConfig() {
 	viper.AutomaticEnv()
 
 	viper.SetDefault("bootstrap.servers", "localhost:29092")
+}
+
+func init() {
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Erro ao ler o arquivo de configuração: %s", err))
+	}
+}
+
+func GetKafkaProducer() (sarama.SyncProducer, error) {
+	kafkaHost := viper.GetString("kafka.host")
+	kafkaPort := viper.GetString("kafka.port")
+	config := sarama.NewConfig()
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+	return sarama.NewSyncProducer([]string{kafkaHost + ":" + kafkaPort}, config)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,16 @@ func main() {
 		if err != nil {
 			fmt.Println("Erro ao consumir tópico:", err)
 		}
+	case "produce":
+		if len(os.Args) < 4 {
+			fmt.Println("Por favor, especifique a mensagem a ser enviada.")
+			return
+		}
+		message := os.Args[3]
+		err := kviewer.Produce(topic, message)
+		if err != nil {
+			fmt.Println("Erro ao produzir mensagem:", err)
+		}
 	default:
 		fmt.Println("Ação desconhecida")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,4 +50,5 @@ func printHelp() {
 	fmt.Println("")
 	fmt.Println("Comandos disponíveis:")
 	fmt.Println("consume <meu-topico> - Consumir mensagens de um tópico específico.")
+	fmt.Println("produce <meu-topico> <mensagem>- Consumir mensagens de um tópico específico.")
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+kafka:
+  host: "localhost"
+  port: "29092"

--- a/pkg/kviewer/config.go
+++ b/pkg/kviewer/config.go
@@ -1,0 +1,35 @@
+package kviewer
+
+import (
+	"fmt"
+
+	"github.com/IBM/sarama"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Erro ao ler o arquivo de configuração: %s", err))
+	}
+}
+
+func GetKafkaProducer() (sarama.SyncProducer, error) {
+	kafkaHost := viper.GetString("kafka.host")
+	kafkaPort := viper.GetString("kafka.port")
+	config := sarama.NewConfig()
+	config.Producer.Return.Successes = true
+	config.Producer.Return.Errors = true
+	return sarama.NewSyncProducer([]string{kafkaHost + ":" + kafkaPort}, config)
+}
+
+func GetKafkaConsumer() (sarama.Consumer, error) {
+	kafkaHost := viper.GetString("kafka.host")
+	kafkaPort := viper.GetString("kafka.port")
+	config := sarama.NewConfig()
+	config.Consumer.Return.Errors = true
+	return sarama.NewConsumer([]string{kafkaHost + ":" + kafkaPort}, config)
+}

--- a/pkg/kviewer/consumer.go
+++ b/pkg/kviewer/consumer.go
@@ -5,17 +5,10 @@ import (
 	"fmt"
 
 	"github.com/IBM/sarama"
-	"github.com/spf13/viper"
 )
 
 func Consume(topic string, maxMsgs int) error {
-	bootstrapServers := viper.GetString("bootstrap.servers")
-
-	config := sarama.NewConfig()
-	config.Consumer.Return.Errors = true
-
-	brokers := []string{bootstrapServers}
-	client, err := sarama.NewConsumer(brokers, config)
+	client, err := GetKafkaConsumer()
 	if err != nil {
 		return fmt.Errorf("failed to create consumer: %s", err)
 	}
@@ -27,7 +20,7 @@ func Consume(topic string, maxMsgs int) error {
 	}
 
 	msgCount := 0
-	unlimited := (maxMsgs == 0) // Se maxMsgs é 0, então consuma indefinidamente
+	unlimited := (maxMsgs == 0)
 
 	for _, partition := range partitions {
 		consumer, err := client.ConsumePartition(topic, partition, sarama.OffsetOldest)

--- a/pkg/kviewer/produce.go
+++ b/pkg/kviewer/produce.go
@@ -1,0 +1,21 @@
+package kviewer
+
+import (
+	"github.com/IBM/sarama"
+)
+
+func Produce(topic string, message string) error {
+	producer, err := GetKafkaProducer()
+	if err != nil {
+		return err
+	}
+	defer producer.Close()
+
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.StringEncoder(message),
+	}
+
+	_, _, err = producer.SendMessage(msg)
+	return err
+}


### PR DESCRIPTION
This PR introduces a new feature to the KViewer that enables writing messages to a Kafka topic. The feature is implemented by adding a new Produce function in the kviewer package, which takes a topic name and a message as arguments, and sends the message to the specified Kafka topic. Furthermore, this PR includes a refactor of the Kafka connection code into a separate package, improving code organization and allowing for better reuse of the Kafka connection logic. Additionally, error handling and configuration management have been enhanced to improve the overall robustness and usability of the application.

This new feature enhances the capabilities of the KViewer by not only allowing users to consume messages from a Kafka topic but also to produce messages to a topic, making the tool more versatile for testing and debugging Kafka applications.

Please review the changes and provide any feedback or suggestions.




